### PR TITLE
Escape IRC nick to prevent self-pinging

### DIFF
--- a/discordc.py
+++ b/discordc.py
@@ -4,6 +4,7 @@ import asyncio
 from asyncio import coroutines
 import concurrent.futures
 from asyncio import futures
+from text_util import toMathSans
 
 logging.basicConfig(level=logging.INFO)
 
@@ -81,7 +82,10 @@ async def on_message(message):
     if len(message.attachments) > 0:
         content += ' ' + message.attachments[0].url
 
-    irc.send_my_message("%s: %s" % (message.author.name, content))
+    # Note(jpc) for nick escaping
+    authorName = toMathSans(message.author.name)
+    irc.send_my_message("%s: %s" % (authorName, content))
+
 
 @client.event
 async def on_ready():

--- a/text_util.py
+++ b/text_util.py
@@ -1,0 +1,12 @@
+def toMathSans(text):
+    # convert alphabetic characters to Math Sans, for nick escaping
+    result = ''
+    for c in text:
+        o = ord(c)
+        if o >= 0x0061 and o <= 0x007a:
+            result += chr(o - 0x0061 + 0x1d5ba)
+        elif o >= 0x0041 and o <= 0x005a:
+            result += chr(o - 0x0041 + 0x1d5a0)
+        else:
+            result += c
+    return result


### PR DESCRIPTION
This modifies the name sent in the irc message, such that the sender does not self-ping everytime.
What it does is replace the alphabetic characters with equivalences from the unicode MathSans character range.

Example
`Redtide123` → `𝖱𝖾𝖽𝗍𝗂𝖽𝖾123`